### PR TITLE
[SonataExtraBundle] delete batch object check base on patch

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -222,6 +222,9 @@
             "target-directory": "vendor-bin"
         },
         "patches": {
+            "sonata-project/doctrine-orm-admin-bundle": {
+                "Batch model delete check": "https://github.com/mpoiriert/SonataDoctrineORMAdminBundle/commit/9f9768c99d63020e3b9168d4456edf2a3dc97cca.patch"
+            }
         }
     },
     "scripts": {

--- a/packages/sonata-extra-bundle/DependencyInjection/Configuration.php
+++ b/packages/sonata-extra-bundle/DependencyInjection/Configuration.php
@@ -3,6 +3,7 @@
 namespace Draw\Bundle\SonataExtraBundle\DependencyInjection;
 
 use Draw\Bundle\SonataExtraBundle\Extension\AutoActionExtension;
+use Sonata\DoctrineORMAdminBundle\Event\PreObjectDeleteBatchEvent;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
@@ -21,6 +22,7 @@ class Configuration implements ConfigurationInterface
                 ->booleanNode('install_assets')->defaultTrue()->end()
                 ->append($this->createAutoActionNode())
                 ->append($this->createAutoHelpNode())
+                ->append($this->createBatchDeleteCheckNode())
                 ->append($this->createCanSecurityHandlerNode())
                 ->append($this->createFixMenuDepthNode())
                 ->append($this->createListFieldPriorityNode())
@@ -36,6 +38,17 @@ class Configuration implements ConfigurationInterface
     {
         return (new ArrayNodeDefinition('auto_help'))
             ->canBeEnabled();
+    }
+
+    private function createBatchDeleteCheckNode(): ArrayNodeDefinition
+    {
+        $node = new ArrayNodeDefinition('batch_delete_check');
+
+        class_exists(PreObjectDeleteBatchEvent::class)
+            ? $node->canBeDisabled()
+            : $node->canBeEnabled();
+
+        return $node;
     }
 
     private function createNotifierNode(): ArrayNodeDefinition

--- a/packages/sonata-extra-bundle/DependencyInjection/DrawSonataExtraExtension.php
+++ b/packages/sonata-extra-bundle/DependencyInjection/DrawSonataExtraExtension.php
@@ -7,6 +7,7 @@ use Draw\Bundle\SonataExtraBundle\Block\MonitoringBlockService;
 use Draw\Bundle\SonataExtraBundle\Controller\AdminControllerInterface;
 use Draw\Bundle\SonataExtraBundle\EventListener\AutoHelpListener;
 use Draw\Bundle\SonataExtraBundle\EventListener\FixDepthMenuBuilderListener;
+use Draw\Bundle\SonataExtraBundle\EventListener\PreObjectDeleteBatchEventEventListener;
 use Draw\Bundle\SonataExtraBundle\EventListener\SessionTimeoutRequestListener;
 use Draw\Bundle\SonataExtraBundle\Extension\AutoActionExtension;
 use Draw\Bundle\SonataExtraBundle\Extension\ListFieldPriorityExtension;
@@ -44,6 +45,10 @@ class DrawSonataExtraExtension extends Extension implements PrependExtensionInte
 
         if (!($config['auto_help']['enabled'] ?? false)) {
             $container->removeDefinition(AutoHelpListener::class);
+        }
+
+        if (!($config['batch_delete_check']['enabled'] ?? false)) {
+            $container->removeDefinition(PreObjectDeleteBatchEventEventListener::class);
         }
 
         if (!($config['fix_menu_depth']['enabled'] ?? false)) {

--- a/packages/sonata-extra-bundle/EventListener/PreObjectDeleteBatchEventEventListener.php
+++ b/packages/sonata-extra-bundle/EventListener/PreObjectDeleteBatchEventEventListener.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Draw\Bundle\SonataExtraBundle\EventListener;
+
+use Sonata\AdminBundle\Admin\Pool;
+use Sonata\DoctrineORMAdminBundle\Event\PreObjectDeleteBatchEvent;
+use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
+
+class PreObjectDeleteBatchEventEventListener
+{
+    public function __construct(private Pool $pool)
+    {
+    }
+
+    #[AsEventListener]
+    public function handlePreObjectDeleteBatchEvent(PreObjectDeleteBatchEvent $event): void
+    {
+        $canDelete = $this->pool
+            ->getAdminByClass($event->getClassName())
+            ->hasAccess('delete', $event->getObject());
+
+        if (!$canDelete) {
+            $event->preventDelete();
+        }
+    }
+}

--- a/packages/sonata-extra-bundle/Tests/DependencyInjection/ConfigurationTest.php
+++ b/packages/sonata-extra-bundle/Tests/DependencyInjection/ConfigurationTest.php
@@ -25,6 +25,9 @@ class ConfigurationTest extends ConfigurationTestCase
             'auto_help' => [
                 'enabled' => false,
             ],
+            'batch_delete_check' => [
+                'enabled' => true,
+            ],
             'can_security_handler' => [
                 'enabled' => false,
                 'grant_by_default' => true,

--- a/packages/sonata-extra-bundle/Tests/DependencyInjection/DrawSonataExtraExtensionAutoActionEnabledTest.php
+++ b/packages/sonata-extra-bundle/Tests/DependencyInjection/DrawSonataExtraExtensionAutoActionEnabledTest.php
@@ -16,6 +16,7 @@ class DrawSonataExtraExtensionAutoActionEnabledTest extends DrawSonataExtraExten
     public function getConfiguration(): array
     {
         return [
+            ...parent::getConfiguration(),
             'auto_action' => [
                 'enabled' => true,
             ],

--- a/packages/sonata-extra-bundle/Tests/DependencyInjection/DrawSonataExtraExtensionAutoHelpEnabledTest.php
+++ b/packages/sonata-extra-bundle/Tests/DependencyInjection/DrawSonataExtraExtensionAutoHelpEnabledTest.php
@@ -16,6 +16,7 @@ class DrawSonataExtraExtensionAutoHelpEnabledTest extends DrawSonataExtraExtensi
     public function getConfiguration(): array
     {
         return [
+            ...parent::getConfiguration(),
             'auto_help' => [
                 'enabled' => true,
             ],

--- a/packages/sonata-extra-bundle/Tests/DependencyInjection/DrawSonataExtraExtensionBatchDeleteCheckEnabledTest.php
+++ b/packages/sonata-extra-bundle/Tests/DependencyInjection/DrawSonataExtraExtensionBatchDeleteCheckEnabledTest.php
@@ -1,12 +1,13 @@
 <?php
 
-namespace Draw\Bundle\SonataExtraBundle\Tests\DependencyInjection;
+namespace DependencyInjection;
 
 use Draw\Bundle\SonataExtraBundle\DependencyInjection\DrawSonataExtraExtension;
-use Draw\Bundle\SonataExtraBundle\EventListener\FixDepthMenuBuilderListener;
+use Draw\Bundle\SonataExtraBundle\EventListener\PreObjectDeleteBatchEventEventListener;
+use Draw\Bundle\SonataExtraBundle\Tests\DependencyInjection\DrawSonataExtraExtensionTest;
 use Symfony\Component\DependencyInjection\Extension\Extension;
 
-class DrawSonataExtraExtensionFixMenuDeptEnabledTest extends DrawSonataExtraExtensionTest
+class DrawSonataExtraExtensionBatchDeleteCheckEnabledTest extends DrawSonataExtraExtensionTest
 {
     public function createExtension(): Extension
     {
@@ -17,7 +18,7 @@ class DrawSonataExtraExtensionFixMenuDeptEnabledTest extends DrawSonataExtraExte
     {
         return [
             ...parent::getConfiguration(),
-            'fix_menu_depth' => [
+            'batch_delete_check' => [
                 'enabled' => true,
             ],
         ];
@@ -26,6 +27,6 @@ class DrawSonataExtraExtensionFixMenuDeptEnabledTest extends DrawSonataExtraExte
     public static function provideTestHasServiceDefinition(): iterable
     {
         yield from parent::provideTestHasServiceDefinition();
-        yield [FixDepthMenuBuilderListener::class];
+        yield [PreObjectDeleteBatchEventEventListener::class];
     }
 }

--- a/packages/sonata-extra-bundle/Tests/DependencyInjection/DrawSonataExtraExtensionCanSecurityHandlerEnabledTest.php
+++ b/packages/sonata-extra-bundle/Tests/DependencyInjection/DrawSonataExtraExtensionCanSecurityHandlerEnabledTest.php
@@ -19,6 +19,7 @@ class DrawSonataExtraExtensionCanSecurityHandlerEnabledTest extends DrawSonataEx
     public function getConfiguration(): array
     {
         return [
+            ...parent::getConfiguration(),
             'can_security_handler' => [
                 'enabled' => true,
                 'prevent_delete_voter' => [

--- a/packages/sonata-extra-bundle/Tests/DependencyInjection/DrawSonataExtraExtensionNotifierEnabledTest.php
+++ b/packages/sonata-extra-bundle/Tests/DependencyInjection/DrawSonataExtraExtensionNotifierEnabledTest.php
@@ -17,6 +17,7 @@ class DrawSonataExtraExtensionNotifierEnabledTest extends DrawSonataExtraExtensi
     public function getConfiguration(): array
     {
         return [
+            ...parent::getConfiguration(),
             'notifier' => [
                 'enabled' => true,
             ],

--- a/packages/sonata-extra-bundle/Tests/DependencyInjection/DrawSonataExtraExtensionSessionTimeoutEnabledTest.php
+++ b/packages/sonata-extra-bundle/Tests/DependencyInjection/DrawSonataExtraExtensionSessionTimeoutEnabledTest.php
@@ -16,6 +16,7 @@ class DrawSonataExtraExtensionSessionTimeoutEnabledTest extends DrawSonataExtraE
     public function getConfiguration(): array
     {
         return [
+            ...parent::getConfiguration(),
             'session_timeout' => [
                 'enabled' => true,
                 'delay' => 900,

--- a/packages/sonata-extra-bundle/Tests/DependencyInjection/DrawSonataExtraExtensionTest.php
+++ b/packages/sonata-extra-bundle/Tests/DependencyInjection/DrawSonataExtraExtensionTest.php
@@ -35,7 +35,11 @@ class DrawSonataExtraExtensionTest extends ExtensionTestCase
 
     public function getConfiguration(): array
     {
-        return [];
+        return [
+            'batch_delete_check' => [
+                'enabled' => false,
+            ],
+        ];
     }
 
     public static function provideTestHasServiceDefinition(): iterable

--- a/packages/sonata-extra-bundle/composer.json
+++ b/packages/sonata-extra-bundle/composer.json
@@ -10,6 +10,7 @@
         "symfony/expression-language": "^6.4.0"
     },
     "require-dev": {
+        "cweagans/composer-patches": "^1.7",
         "draw/tester": "^0.11",
         "draw/security": "^0.11",
         "phpunit/phpunit": "^9.0 || ^10.0",
@@ -24,9 +25,19 @@
             "Draw\\Bundle\\SonataExtraBundle\\": ""
         }
     },
+    "config": {
+        "allow-plugins": {
+            "cweagans/composer-patches": true
+        }
+    },
     "extra": {
         "branch-alias": {
             "dev-master": "0.11-dev"
+        },
+        "patches": {
+            "sonata-project/doctrine-orm-admin-bundle": {
+                "Batch model delete check": "https://github.com/mpoiriert/SonataDoctrineORMAdminBundle/commit/9f9768c99d63020e3b9168d4456edf2a3dc97cca.patch"
+            }
         }
     }
 }

--- a/tests/SonataExtraBundle/EventListener/PreObjectDeleteBatchEventEventListenerTest.php
+++ b/tests/SonataExtraBundle/EventListener/PreObjectDeleteBatchEventEventListenerTest.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace App\Tests\SonataExtraBundle\EventListener;
+
+use App\Entity\User;
+use App\Security\Voter\CannotDeleteSelfVoter;
+use Doctrine\ORM\EntityManagerInterface;
+use Draw\Bundle\SonataExtraBundle\EventListener\PreObjectDeleteBatchEventEventListener;
+use Draw\Bundle\TesterBundle\PHPUnit\Extension\SetUpAutowire\AutowiredInterface;
+use Draw\Bundle\TesterBundle\PHPUnit\Extension\SetUpAutowire\AutowireService;
+use Sonata\DoctrineORMAdminBundle\Event\PreObjectDeleteBatchEvent;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Security\Core\Authentication\Token\AbstractToken;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+
+class PreObjectDeleteBatchEventEventListenerTest extends KernelTestCase implements AutowiredInterface
+{
+    #[AutowireService]
+    private PreObjectDeleteBatchEventEventListener $object;
+
+    #[AutowireService]
+    private TokenStorageInterface $tokenStorage;
+
+    #[AutowireService]
+    private EntityManagerInterface $entityManager;
+
+    public function testHandlePreObjectDeleteBatchEventCannotDelete(): void
+    {
+        $user = $this->entityManager
+            ->getRepository(User::class)
+            ->findOneBy(['email' => 'admin@example.com']);
+
+        $this->connectUser($user);
+
+        $this->object->handlePreObjectDeleteBatchEvent(
+            $event = new PreObjectDeleteBatchEvent(
+                User::class,
+                $user
+            )
+        );
+
+        static::assertFalse(
+            $event->shouldDelete(),
+            CannotDeleteSelfVoter::class.' should prevent deletion of the user.'
+        );
+    }
+
+    public function testHandlePreObjectDeleteBatchEventCanDelete(): void
+    {
+        $user = $this->entityManager
+            ->getRepository(User::class)
+            ->findOneBy(['email' => 'admin@example.com']);
+
+        $this->connectUser($user);
+
+        $this->object->handlePreObjectDeleteBatchEvent(
+            $event = new PreObjectDeleteBatchEvent(
+                User::class,
+                new User()
+            )
+        );
+
+        static::assertTrue(
+            $event->shouldDelete()
+        );
+    }
+
+    private function connectUser(User $user): void
+    {
+        $this->tokenStorage
+            ->setToken(
+                new class($user) extends AbstractToken {
+                    public function __construct(User $user)
+                    {
+                        parent::__construct(['ROLE_SUPER_ADMIN']);
+
+                        $this->setUser($user);
+                    }
+
+                    public function getCredentials()
+                    {
+                        return null;
+                    }
+                }
+            );
+    }
+}


### PR DESCRIPTION
If this patch https://github.com/mpoiriert/SonataDoctrineORMAdminBundle/commit/9f9768c99d63020e3b9168d4456edf2a3dc97cca.patch is applied an event is dispatched for object on  "delete batch".

If configuration is enabled a "hasAccess" delete will be check for each object to prevent deletion.