### PR TITLE
[TesterBundle] PHPUnit SetUpAutowire extension refactoring and support AutowireParameter

### DIFF
--- a/app/src/Repository/TagRepository.php
+++ b/app/src/Repository/TagRepository.php
@@ -13,7 +13,7 @@ class TagRepository extends ServiceEntityRepository
         parent::__construct($registry, Tag::class);
     }
 
-    public function findActive()
+    public function findActive(): array
     {
         return $this->findBy(['active' => true]);
     }

--- a/packages/tester-bundle/PHPUnit/Extension/SetUpAutowire/AutowireClient.php
+++ b/packages/tester-bundle/PHPUnit/Extension/SetUpAutowire/AutowireClient.php
@@ -4,9 +4,19 @@ declare(strict_types=1);
 
 namespace Draw\Bundle\TesterBundle\PHPUnit\Extension\SetUpAutowire;
 
+use Draw\Bundle\TesterBundle\WebTestCase as DrawWebTestCase;
+use Draw\Component\Core\Reflection\ReflectionAccessor;
+use PHPUnit\Framework\TestCase;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase as SymfonyWebTestCase;
+
 #[\Attribute(\Attribute::TARGET_PROPERTY)]
-class AutowireClient
+class AutowireClient implements AutowireInterface
 {
+    public static function getPriority(): int
+    {
+        return 1000;
+    }
+
     public function __construct(
         private array $options = [],
         private array $server = [],
@@ -21,5 +31,35 @@ class AutowireClient
     public function getServer(): array
     {
         return $this->server;
+    }
+
+    public function autowire(TestCase $testCase, \ReflectionProperty $reflectionProperty): void
+    {
+        if (!$testCase instanceof SymfonyWebTestCase && !$testCase instanceof DrawWebTestCase) {
+            throw new \RuntimeException(
+                sprintf(
+                    'AutowireClient attribute can only be used in %s or %s.',
+                    SymfonyWebTestCase::class,
+                    DrawWebTestCase::class
+                )
+            );
+        }
+
+        // This is to ensure the kernel is not booted before calling createClient
+        // Can happen if we use the container in a setUpBeforeClass method or a beforeClass hook
+        ReflectionAccessor::callMethod(
+            $testCase,
+            'ensureKernelShutdown'
+        );
+
+        $reflectionProperty->setValue(
+            $testCase,
+            ReflectionAccessor::callMethod(
+                $testCase,
+                'createClient',
+                $this->getOptions(),
+                $this->getServer()
+            )
+        );
     }
 }

--- a/packages/tester-bundle/PHPUnit/Extension/SetUpAutowire/AutowireInterface.php
+++ b/packages/tester-bundle/PHPUnit/Extension/SetUpAutowire/AutowireInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Draw\Bundle\TesterBundle\PHPUnit\Extension\SetUpAutowire;
+
+use PHPUnit\Framework\TestCase;
+
+interface AutowireInterface
+{
+    public static function getPriority(): int;
+
+    public function autowire(TestCase $testCase, \ReflectionProperty $reflectionProperty);
+}

--- a/packages/tester-bundle/PHPUnit/Extension/SetUpAutowire/AutowireMock.php
+++ b/packages/tester-bundle/PHPUnit/Extension/SetUpAutowire/AutowireMock.php
@@ -2,7 +2,48 @@
 
 namespace Draw\Bundle\TesterBundle\PHPUnit\Extension\SetUpAutowire;
 
+use Draw\Component\Core\Reflection\ReflectionAccessor;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
 #[\Attribute(\Attribute::TARGET_PROPERTY)]
-class AutowireMock extends AutowireService
+class AutowireMock implements AutowireInterface
 {
+    public static function getPriority(): int
+    {
+        return 255;
+    }
+
+    public function autowire(TestCase $testCase, \ReflectionProperty $reflectionProperty): void
+    {
+        $propertyName = $reflectionProperty->getName();
+        $type = $reflectionProperty->getType();
+
+        if (!$type instanceof \ReflectionIntersectionType) {
+            throw new \RuntimeException('Property '.$propertyName.' of class '.$testCase::class.' must have a type hint intersection with Mock.');
+        }
+
+        $types = $type->getTypes();
+
+        if (2 !== \count($types)) {
+            throw new \RuntimeException('Property '.$propertyName.' of class '.$testCase::class.' can only have 2 intersection types.');
+        }
+
+        foreach ($types as $type) {
+            if (!$type instanceof \ReflectionNamedType) {
+                throw new \RuntimeException('Property '.$propertyName.' of class '.$testCase::class.' intersection must be of named type.');
+            }
+
+            if (MockObject::class === $type->getName()) {
+                continue;
+            }
+
+            $reflectionProperty->setValue(
+                $testCase,
+                ReflectionAccessor::callMethod($testCase, 'createMock', $type->getName())
+            );
+
+            return;
+        }
+    }
 }

--- a/packages/tester-bundle/PHPUnit/Extension/SetUpAutowire/AutowireMockProperty.php
+++ b/packages/tester-bundle/PHPUnit/Extension/SetUpAutowire/AutowireMockProperty.php
@@ -2,9 +2,17 @@
 
 namespace Draw\Bundle\TesterBundle\PHPUnit\Extension\SetUpAutowire;
 
+use Draw\Component\Core\Reflection\ReflectionAccessor;
+use PHPUnit\Framework\TestCase;
+
 #[\Attribute(\Attribute::TARGET_PROPERTY | \Attribute::IS_REPEATABLE)]
-class AutowireMockProperty
+class AutowireMockProperty implements AutowireInterface
 {
+    public static function getPriority(): int
+    {
+        return -100;
+    }
+
     public function __construct(private string $property, private ?string $fromProperty = null)
     {
         $this->fromProperty ??= $property;
@@ -18,5 +26,19 @@ class AutowireMockProperty
     public function getFromProperty(): string
     {
         return $this->fromProperty;
+    }
+
+    public function autowire(TestCase $testCase, \ReflectionProperty $reflectionProperty): void
+    {
+        $object = $reflectionProperty->getValue($testCase);
+
+        ReflectionAccessor::setPropertyValue(
+            $object,
+            $this->getProperty(),
+            ReflectionAccessor::getPropertyValue(
+                $testCase,
+                $this->getFromProperty()
+            )
+        );
     }
 }

--- a/packages/tester-bundle/PHPUnit/Extension/SetUpAutowire/AutowireParameter.php
+++ b/packages/tester-bundle/PHPUnit/Extension/SetUpAutowire/AutowireParameter.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Draw\Bundle\TesterBundle\PHPUnit\Extension\SetUpAutowire;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
+
+#[\Attribute(\Attribute::TARGET_PROPERTY)]
+class AutowireParameter implements AutowireInterface
+{
+    public static function getPriority(): int
+    {
+        return 0;
+    }
+
+    public function __construct(private string $parameter)
+    {
+    }
+
+    public function getParameter(): string
+    {
+        return $this->parameter;
+    }
+
+    public function autowire(TestCase $testCase, \ReflectionProperty $reflectionProperty): void
+    {
+        \assert($testCase instanceof KernelTestCase);
+
+        $container = (new \ReflectionMethod($testCase, 'getContainer'))->invoke($testCase);
+
+        $reflectionProperty->setValue(
+            $testCase,
+            $container->get(ParameterBagInterface::class)->resolveValue($this->getParameter())
+        );
+    }
+}

--- a/packages/tester-bundle/PHPUnit/Extension/SetUpAutowire/AutowireService.php
+++ b/packages/tester-bundle/PHPUnit/Extension/SetUpAutowire/AutowireService.php
@@ -2,9 +2,18 @@
 
 namespace Draw\Bundle\TesterBundle\PHPUnit\Extension\SetUpAutowire;
 
+use Draw\Component\Core\Reflection\ReflectionExtractor;
+use PHPUnit\Framework\TestCase;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
 #[\Attribute(\Attribute::TARGET_PROPERTY)]
-class AutowireService
+class AutowireService implements AutowireInterface
 {
+    public static function getPriority(): int
+    {
+        return 0;
+    }
+
     public function __construct(private ?string $serviceId = null)
     {
     }
@@ -12,5 +21,29 @@ class AutowireService
     public function getServiceId(): ?string
     {
         return $this->serviceId;
+    }
+
+    public function autowire(TestCase $testCase, \ReflectionProperty $reflectionProperty): void
+    {
+        \assert($testCase instanceof KernelTestCase);
+
+        $serviceId = $this->serviceId;
+
+        if (null === $serviceId) {
+            $classes = ReflectionExtractor::getClasses($reflectionProperty->getType());
+
+            if (1 !== \count($classes)) {
+                throw new \RuntimeException('Property '.$reflectionProperty->getName().' of class '.$testCase::class.' must have a type hint.');
+            }
+
+            $serviceId = $classes[0];
+        }
+
+        $container = (new \ReflectionMethod($testCase, 'getContainer'))->invoke($testCase);
+
+        $reflectionProperty->setValue(
+            $testCase,
+            $container->get($serviceId)
+        );
     }
 }

--- a/packages/tester-bundle/extension.neon
+++ b/packages/tester-bundle/extension.neon
@@ -2,13 +2,6 @@ services:
     draw.tester_bundle.autowire_client_read_write_properties_extension:
         class: Draw\Bundle\TesterBundle\PHPStan\Rules\Properties\AutowireReadWritePropertiesExtension
         arguments:
-            - 'Draw\Bundle\TesterBundle\PHPUnit\Extension\SetUpAutowire\AutowireClient'
-        tags:
-            - phpstan.properties.readWriteExtension
-
-    draw.tester_bundle.autowire_service_read_write_properties_extension:
-        class: Draw\Bundle\TesterBundle\PHPStan\Rules\Properties\AutowireReadWritePropertiesExtension
-        arguments:
-            - 'Draw\Bundle\TesterBundle\PHPUnit\Extension\SetUpAutowire\AutowireService'
+            - 'Draw\Bundle\TesterBundle\PHPUnit\Extension\SetUpAutowire\AutowireInterface'
         tags:
             - phpstan.properties.readWriteExtension

--- a/tests/TesterBundle/PHPUnit/Extension/SetUpAutoWire/SetUpAutowireExtensionTest.php
+++ b/tests/TesterBundle/PHPUnit/Extension/SetUpAutoWire/SetUpAutowireExtensionTest.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace App\Tests\TesterBundle\PHPUnit\Extension\SetUpAutoWire;
+
+use App\EntityMigration\UserSetCommentNullMigration;
+use Doctrine\Persistence\ManagerRegistry;
+use Draw\Bundle\TesterBundle\Messenger\TransportTester;
+use Draw\Bundle\TesterBundle\PHPUnit\Extension\SetUpAutowire\AutowireClient;
+use Draw\Bundle\TesterBundle\PHPUnit\Extension\SetUpAutowire\AutowiredInterface;
+use Draw\Bundle\TesterBundle\PHPUnit\Extension\SetUpAutowire\AutowireMock;
+use Draw\Bundle\TesterBundle\PHPUnit\Extension\SetUpAutowire\AutowireMockProperty;
+use Draw\Bundle\TesterBundle\PHPUnit\Extension\SetUpAutowire\AutowireParameter;
+use Draw\Bundle\TesterBundle\PHPUnit\Extension\SetUpAutowire\AutowireService;
+use Draw\Bundle\TesterBundle\PHPUnit\Extension\SetUpAutowire\AutowireTransportTester;
+use PHPUnit\Framework\MockObject\MockObject;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+class SetUpAutowireExtensionTest extends WebTestCase implements AutowiredInterface
+{
+    #[
+        AutowireService,
+        AutowireMockProperty('managerRegistry')
+    ]
+    private UserSetCommentNullMigration $userSetCommentNullMigration;
+
+    #[AutowireMock]
+    private ManagerRegistry&MockObject $managerRegistry;
+
+    #[AutowireClient]
+    private KernelBrowser $client;
+
+    #[AutowireTransportTester('sync')]
+    private TransportTester $transportTester;
+
+    #[AutowireParameter('%kernel.environment%_resolved')]
+    private string $parameter;
+
+    public function testAutowireService(): void
+    {
+        static::assertSame(
+            static::getContainer()->get(UserSetCommentNullMigration::class),
+            $this->userSetCommentNullMigration
+        );
+    }
+
+    public function testAutowiredClient(): void
+    {
+        static::assertSame(
+            static::getClient(),
+            $this->client
+        );
+    }
+
+    public function testAutowiredMock(): void
+    {
+        static::assertInstanceOf(
+            ManagerRegistry::class,
+            $this->managerRegistry
+        );
+
+        static::assertInstanceOf(
+            MockObject::class,
+            $this->managerRegistry
+        );
+    }
+
+    public function testAutowireMockProperty(): void
+    {
+        static::assertSame(
+            (new \ReflectionProperty($this->userSetCommentNullMigration, 'managerRegistry'))
+                ->getValue($this->userSetCommentNullMigration),
+            $this->managerRegistry
+        );
+    }
+
+    public function testAutowiredTransportTester(): void
+    {
+        static::assertSame(
+            static::getContainer()->get('messenger.transport.sync.draw.tester'),
+            $this->transportTester
+        );
+    }
+
+    public function testAutowiredParameter(): void
+    {
+        static::assertSame(
+            'test_resolved',
+            $this->parameter
+        );
+    }
+}


### PR DESCRIPTION
The extension now rely on AutowireInterace property that will autowire the property them self.

They support priority when the order is important (client, mock, mock property have ordering dependencies).

New AutowireParameter also added.