### PR TITLE
[OpenApi] Better support for Dynamic Object and union

### DIFF
--- a/.github/workflows/after_splitting_test.yaml
+++ b/.github/workflows/after_splitting_test.yaml
@@ -53,6 +53,7 @@ jobs:
         with:
           php-version: '8.2'
           coverage: none
+          extensions: mongodb-1.17.3
 
       - name: Setup MySQL
         uses: 'shogo82148/actions-setup-mysql@v1'

--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -25,6 +25,7 @@ jobs:
         with:
           php-version: '8.2'
           tools: composer
+          extensions: mongodb-1.17.3
       - name: Composer
         run: composer install
       - name: Composer for vendor-bin

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -25,6 +25,7 @@ jobs:
         with:
           php-version: '8.2'
           tools: composer
+          extensions: mongodb-1.17.3
       - name: Composer
         run: composer install
       - name: Composer for vendor-bin

--- a/packages/open-api/Extraction/Extractor/JmsSerializer/TypeHandler/DynamicObjectHandler.php
+++ b/packages/open-api/Extraction/Extractor/JmsSerializer/TypeHandler/DynamicObjectHandler.php
@@ -16,12 +16,23 @@ class DynamicObjectHandler implements TypeToSchemaHandlerInterface
             return null;
         }
 
-        $propertySchema = new Schema();
-        $propertySchema->type = 'object';
-        $propertySchema->additionalProperties = new Schema();
-        $propertySchema->additionalProperties->type = $type;
+        if ('mixed' === $type) {
+            $propertySchema = true;
+        } else {
+            $extractionContext->getOpenApi()
+                ->extract(
+                    $type,
+                    $propertySchema = new Schema(),
+                    $extractionContext
+                )
+            ;
+        }
 
-        return $propertySchema;
+        $schema = new Schema();
+        $schema->type = 'object';
+        $schema->additionalProperties = $propertySchema;
+
+        return $schema;
     }
 
     private function getDynamicObjectType(PropertyMetadata $item): ?string

--- a/packages/open-api/OpenApi.php
+++ b/packages/open-api/OpenApi.php
@@ -13,9 +13,11 @@ use Draw\Component\OpenApi\Extraction\ExtractorInterface;
 use Draw\Component\OpenApi\Schema\Operation;
 use Draw\Component\OpenApi\Schema\Root as Schema;
 use Draw\Component\OpenApi\Serializer\Handler\OpenApiHandler;
+use Draw\Component\OpenApi\Serializer\Subscriber\BasicUnionDeserializerSubscriber;
 use Draw\Component\OpenApi\Serializer\Subscriber\OpenApiSubscriber;
 use JMS\Serializer\EventDispatcher\EventDispatcher;
 use JMS\Serializer\Handler\HandlerRegistry;
+use JMS\Serializer\Handler\UnionHandler;
 use JMS\Serializer\SerializerBuilder;
 use JMS\Serializer\SerializerInterface;
 use Symfony\Component\EventDispatcher\EventDispatcher as SymfonyEventDispatcher;
@@ -46,11 +48,13 @@ class OpenApi
                 ->configureListeners(
                     static function (EventDispatcher $dispatcher): void {
                         $dispatcher->addSubscriber(new OpenApiSubscriber());
+                        $dispatcher->addSubscriber(new BasicUnionDeserializerSubscriber());
                     }
                 )
                 ->configureHandlers(
                     static function (HandlerRegistry $handlerRegistry): void {
                         $handlerRegistry->registerSubscribingHandler(new OpenApiHandler());
+                        $handlerRegistry->registerSubscribingHandler(new UnionHandler());
                     }
                 )
                 ->build()

--- a/packages/open-api/Schema/Schema.php
+++ b/packages/open-api/Schema/Schema.php
@@ -83,9 +83,14 @@ class Schema implements GroupSequenceProviderInterface, VendorExtensionSupportIn
     #[JMS\Type('array<string,'.self::class.'>')]
     public ?array $properties = null;
 
-    #[Assert\Valid]
-    #[JMS\SerializedName('additionalProperties')]
-    public ?Schema $additionalProperties = null;
+    #[
+        JMS\SerializedName('additionalProperties'),
+    ]
+    #[
+        Assert\Type(type: ['bool', self::class]),
+        Assert\Valid(groups: ['AdditionalProperties']),
+    ]
+    public Schema|bool|null $additionalProperties = null;
 
     /**
      * Adds support for polymorphism.
@@ -146,6 +151,10 @@ class Schema implements GroupSequenceProviderInterface, VendorExtensionSupportIn
             $groups[] = 'Type';
         } else {
             $groups[] = 'Ref';
+        }
+
+        if ($this->additionalProperties instanceof self) {
+            $groups[] = 'AdditionalProperties';
         }
 
         return $groups;

--- a/packages/open-api/Serializer/Subscriber/BasicUnionDeserializerSubscriber.php
+++ b/packages/open-api/Serializer/Subscriber/BasicUnionDeserializerSubscriber.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Draw\Component\OpenApi\Serializer\Subscriber;
+
+use JMS\Serializer\EventDispatcher\Events;
+use JMS\Serializer\EventDispatcher\EventSubscriberInterface;
+use JMS\Serializer\EventDispatcher\PreDeserializeEvent;
+
+class BasicUnionDeserializerSubscriber implements EventSubscriberInterface
+{
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            [
+                'event' => Events::PRE_DESERIALIZE,
+                'method' => 'onPreDeserialize',
+                'format' => 'json',
+            ],
+        ];
+    }
+
+    public function onPreDeserialize(PreDeserializeEvent $event): void
+    {
+        if ('union' !== $event->getType()['name']) {
+            return;
+        }
+
+        $data = $event->getData();
+
+        $type = get_debug_type($data);
+
+        $class = null;
+        foreach ($event->getType()['params'][0] as $param) {
+            if ($type === $param['name']) {
+                $event->setType($param['name']);
+
+                return;
+            }
+
+            if (!class_exists($param['name'])) {
+                continue;
+            }
+
+            if ('array' === $type) {
+                if (null !== $class) {
+                    return; // More than one type matched we ignore it, maybe the built in UnionHandler will handle it later
+                }
+                $class = $param['name'];
+            }
+        }
+
+        if (null !== $class) {
+            $event->setType($class);
+        }
+    }
+}

--- a/packages/open-api/Tests/DependencyInjection/OpenApiIntegrationTest.php
+++ b/packages/open-api/Tests/DependencyInjection/OpenApiIntegrationTest.php
@@ -68,6 +68,7 @@ use Draw\Component\OpenApi\Serializer\Construction\SimpleObjectConstructor;
 use Draw\Component\OpenApi\Serializer\Handler\GenericSerializerHandler;
 use Draw\Component\OpenApi\Serializer\Handler\ObjectReferenceHandler;
 use Draw\Component\OpenApi\Serializer\Handler\OpenApiHandler;
+use Draw\Component\OpenApi\Serializer\Subscriber\BasicUnionDeserializerSubscriber;
 use Draw\Component\OpenApi\Serializer\Subscriber\OpenApiSubscriber;
 use Draw\Component\OpenApi\Versioning\RouteDefaultApiRouteVersionMatcher;
 use Draw\Component\OpenApi\Versioning\RouteVersionMatcherInterface;
@@ -387,6 +388,10 @@ class OpenApiIntegrationTest extends IntegrationTestCase
                 new ServiceConfiguration(
                     'draw.open_api.jms_serializer.handler.open_api_handler',
                     [OpenApiHandler::class]
+                ),
+                new ServiceConfiguration(
+                    'draw.open_api.jms_serializer.subscriber.basic_union_deserializer_subscriber',
+                    [BasicUnionDeserializerSubscriber::class]
                 ),
                 new ServiceConfiguration(
                     'draw.open_api.jms_serializer.subscriber.open_api_subscriber',


### PR DESCRIPTION
If union as one class (union with base type and only one class) if data is array it will map class automatically.

additionalProperties can now support "true" as a value, as per documentation when object type are not defined.