### PR TITLE
[TesterBundle] Fix AutowireServiceMock broken by Symfony 6.4.34 TestContainer::set() change

### DIFF
--- a/packages/tester-bundle/PHPUnit/Extension/SetUpAutowire/AutowireServiceMock.php
+++ b/packages/tester-bundle/PHPUnit/Extension/SetUpAutowire/AutowireServiceMock.php
@@ -21,7 +21,7 @@ class AutowireServiceMock extends AutowireMock
 
         $value = $reflectionProperty->getValue($testCase);
 
-        $this->getContainer($testCase)->set(
+        $this->getPublicContainer($testCase)->set(
             $this->getServiceId($reflectionProperty),
             $value
         );

--- a/packages/tester-bundle/PHPUnit/Extension/SetUpAutowire/KernelTestCaseAutowireDependentTrait.php
+++ b/packages/tester-bundle/PHPUnit/Extension/SetUpAutowire/KernelTestCaseAutowireDependentTrait.php
@@ -4,6 +4,8 @@ namespace Draw\Bundle\TesterBundle\PHPUnit\Extension\SetUpAutowire;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Bundle\FrameworkBundle\Test\TestContainer;
+use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 trait KernelTestCaseAutowireDependentTrait
@@ -15,6 +17,28 @@ trait KernelTestCaseAutowireDependentTrait
         $container = (new \ReflectionMethod($testCase, 'getContainer'))->invoke($testCase);
 
         \assert($container instanceof ContainerInterface);
+
+        return $container;
+    }
+
+    /**
+     * Returns the real (public) container, bypassing TestContainer.
+     *
+     * This is needed because TestContainer::set() routes services that exist
+     * in the private services locator to $container->privates, but compiled
+     * service factories resolve dependencies from $container->services.
+     */
+    private function getPublicContainer(TestCase $testCase): Container
+    {
+        $container = $this->getContainer($testCase);
+
+        if ($container instanceof TestContainer) {
+            $method = new \ReflectionMethod($container, 'getPublicContainer');
+
+            return $method->invoke($container);
+        }
+
+        \assert($container instanceof Container);
 
         return $container;
     }


### PR DESCRIPTION
## Summary

Symfony 6.4.34 refactored `TestContainer::set()` from a try/catch pattern to a proactive check, which broke mock injection for all services registered in the test private services locator.

### Old behavior (Symfony 6.4.31 — worked)

```php
public function set(string $id, mixed $service): void
{
    $container = $this->getPublicContainer();
    $renamedId = $this->renamedIds[$id] ?? $id;

    try {
        $container->set($renamedId, $service);  // stores in $container->services
    } catch (InvalidArgumentException $e) {
        if (!str_starts_with($e->getMessage(), "The \"$renamedId\" service is private")) {
            throw $e;
        }
        $container->privates[$renamedId] = $service;  // only reached on exception
    }
}
```

`Container::set()` was called first, storing the mock in `$container->services`. The fallback to `$container->privates` only happened if an exception was thrown (which it wasn't for these services).

### New behavior (Symfony 6.4.34 — broken)

```php
public function set(string $id, mixed $service): void
{
    $container = $this->getPublicContainer();
    $renamedId = $this->renamedIds[$id] ?? $id;

    if (!$this->getPrivateContainer()->has($renamedId)) {
        $container->set($renamedId, $service);
    } else {
        $container->privates[$renamedId] = $service;  // always reached in test env
    }
}
```

The new code checks `getPrivateContainer()->has()` first. In the test environment, **all** services are registered in `test.private_services_locator`, so mocks **always** go to `$container->privates` — never reaching `$container->services`.

### Impact

Compiled service factories only resolve dependencies from `$container->services`, so they never see the mocks and create real service instances instead. This causes issues like infinite loops with real HTTP calls leading to OOM (6GB+ memory exhausted).

### Fix

Bypass `TestContainer::set()` entirely by calling `Container::set()` directly on the public container (accessed via reflection on `TestContainer::getPublicContainer()`). This ensures mocks are stored in `$container->services` where compiled factories can find them.