### PR TITLE
[SonataImportBundle] Skip-cell marker to preserve existing values on partial imports

### DIFF
--- a/packages/sonata-import-bundle/Admin/ImportAdmin.php
+++ b/packages/sonata-import-bundle/Admin/ImportAdmin.php
@@ -33,6 +33,8 @@ class ImportAdmin extends AbstractAdmin
         private ImporterInterface $importer,
         #[Autowire('%draw.sonata_import.classes%')]
         private array $importableClassList,
+        #[Autowire('%draw.sonata_import.skip_value%')]
+        private string $skipValue = '_SKIP_',
     ) {
         parent::__construct();
     }
@@ -119,7 +121,10 @@ class ImportAdmin extends AbstractAdmin
                     FileType::class,
                     [
                         'mapped' => false,
-                        'help' => 'CSV File with column headers.',
+                        'help' => \sprintf(
+                            'CSV File with column headers. Use the cell value "%s" to keep the existing value on the entity for that column (only meaningful when updating existing records).',
+                            $this->skipValue
+                        ),
                     ]
                 )
             ->ifEnd()

--- a/packages/sonata-import-bundle/DependencyInjection/Configuration.php
+++ b/packages/sonata-import-bundle/DependencyInjection/Configuration.php
@@ -2,6 +2,7 @@
 
 namespace Draw\Bundle\SonataImportBundle\DependencyInjection;
 
+use Draw\Bundle\SonataImportBundle\Import\Importer;
 use Knp\DoctrineBehaviors\Contract\Entity\TranslatableInterface;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
@@ -21,6 +22,11 @@ class Configuration implements ConfigurationInterface
 
         $node
             ->children()
+                ->scalarNode('skip_value')
+                    ->info('Sentinel value that, when present in a CSV cell, preserves the existing value on the entity for that (row, column) pair instead of overwriting it. The check runs before any type coercion (date, etc.).')
+                    ->defaultValue(Importer::DEFAULT_SKIP_VALUE)
+                    ->cannotBeEmpty()
+                ->end()
                 ->arrayNode('classes')
                     ->beforeNormalization()
                         ->always(static function ($classes) {

--- a/packages/sonata-import-bundle/DependencyInjection/DrawSonataImportExtension.php
+++ b/packages/sonata-import-bundle/DependencyInjection/DrawSonataImportExtension.php
@@ -4,6 +4,7 @@ namespace Draw\Bundle\SonataImportBundle\DependencyInjection;
 
 use Draw\Bundle\SonataImportBundle\Column\Bridge\KnpDoctrineBehaviors\Extractor\DoctrineTranslationColumnExtractor;
 use Draw\Bundle\SonataImportBundle\Column\ColumnExtractorInterface;
+use Draw\Bundle\SonataImportBundle\Import\Importer;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader;
@@ -21,6 +22,12 @@ class DrawSonataImportExtension extends ConfigurableExtension
         ;
 
         $container->setParameter('draw.sonata_import.classes', $mergedConfig['classes']);
+        $container->setParameter('draw.sonata_import.skip_value', $mergedConfig['skip_value']);
+
+        $container
+            ->getDefinition(Importer::class)
+            ->setArgument('$skipValue', $mergedConfig['skip_value'])
+        ;
 
         $this->loadDoctrineTranslationHandler($mergedConfig['handlers']['doctrine_translation'], $container);
     }

--- a/packages/sonata-import-bundle/Import/Importer.php
+++ b/packages/sonata-import-bundle/Import/Importer.php
@@ -16,6 +16,12 @@ use Symfony\Component\PropertyAccess\PropertyAccess;
 
 class Importer implements ImporterInterface
 {
+    /**
+     * Default sentinel value that, when present in a CSV cell, skips assignment for that
+     * (row, column) pair so the existing value on the entity is preserved.
+     */
+    final public const DEFAULT_SKIP_VALUE = '_SKIP_';
+
     public function __construct(
         /**
          * @var iterable<ColumnExtractorInterface>
@@ -25,7 +31,18 @@ class Importer implements ImporterInterface
         private ManagerRegistry $managerRegistry,
         private ColumnFactory $columnFactory,
         private NotifierInterface $notifier,
+        private string $skipValue = self::DEFAULT_SKIP_VALUE,
     ) {
+    }
+
+    public function getSkipValue(): string
+    {
+        return $this->skipValue;
+    }
+
+    public function isSkipValue(mixed $value): bool
+    {
+        return \is_string($value) && $value === $this->skipValue;
     }
 
     public function getOptions(Column $column): array
@@ -174,6 +191,10 @@ class Importer implements ImporterInterface
 
     private function assignValue(object $object, Column $column, mixed $value): void
     {
+        if ($this->isSkipValue($value)) {
+            return;
+        }
+
         if ($column->getIsDate()) {
             $value = new \DateTime($value);
         }

--- a/packages/sonata-import-bundle/README.md
+++ b/packages/sonata-import-bundle/README.md
@@ -15,6 +15,7 @@ Here is an example of the configuration:
 
 ```YAML
 draw_sonata_import:
+  skip_value: '_SKIP_' # Optional, defaults to "_SKIP_". See "Preserving existing values" below.
   classes:
     App\Entity\User:
       alias: 'User' #The alias will be used instead of the full class name in the dropdown and database
@@ -23,6 +24,31 @@ draw_sonata_import:
 ```
 
 This tell the system that it support import for **App\Entity\User** and **App\Entity\Product**.
+
+## Preserving existing values on partial imports
+
+When updating existing entities, an empty cell or any other value is normally written
+to the entity. This is a problem for partial imports — for example, updating only one
+locale of a translatable field while leaving the other locales untouched.
+
+To opt out of writing a given cell, use the **skip value** (default `_SKIP_`):
+
+```csv
+id,translation#en.title,translation#fr.title,translation#pl.title
+42,Ocean kingdom,Royaume océanique,_SKIP_
+```
+
+For row `id=42`, the English and French titles are updated and the Polish title is
+left exactly as it is in the database. The check happens in
+`Importer::assignValue()` *before* any type coercion, so the marker also works on
+date columns, boolean columns, etc.
+
+You can change the marker per project via the `skip_value` configuration key. The
+marker only makes sense on update — on insert (`insertWhenNotFound: true`) a skipped
+column simply leaves the field at its default value.
+
+An empty cell is **not** a skip — it still clears the field. Use the marker explicitly
+when you want to keep the stored value.
 
 ## Sonata admin
 

--- a/packages/sonata-import-bundle/Tests/DependencyInjection/ConfigurationTest.php
+++ b/packages/sonata-import-bundle/Tests/DependencyInjection/ConfigurationTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Draw\Bundle\SonataImportBundle\Tests\DependencyInjection;
+
+use Draw\Bundle\SonataImportBundle\DependencyInjection\Configuration;
+use Draw\Bundle\SonataImportBundle\Import\Importer;
+use Draw\Component\Tester\Test\DependencyInjection\ConfigurationTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
+
+/**
+ * @internal
+ */
+#[CoversClass(Configuration::class)]
+class ConfigurationTest extends ConfigurationTestCase
+{
+    public function createConfiguration(): ConfigurationInterface
+    {
+        return new Configuration();
+    }
+
+    public function getDefaultConfiguration(): array
+    {
+        return [
+            'classes' => [],
+            'skip_value' => Importer::DEFAULT_SKIP_VALUE,
+        ];
+    }
+
+    public function testCustomSkipValue(): void
+    {
+        $config = $this->processConfiguration([['skip_value' => '*SKIP*']]);
+
+        static::assertSame('*SKIP*', $config['skip_value']);
+    }
+
+    public static function provideInvalidConfigurationCases(): iterable
+    {
+        yield 'empty skip_value' => [
+            ['skip_value' => ''],
+            \sprintf(
+                "The path \"draw_sonata_import.skip_value\" cannot contain an empty value, but got \"\".\nHint: %s",
+                'Sentinel value that, when present in a CSV cell, preserves the existing value on the entity for that (row, column) pair instead of overwriting it. The check runs before any type coercion (date, etc.).'
+            ),
+        ];
+    }
+}

--- a/packages/sonata-import-bundle/Tests/Import/Fixtures/CallTrackingColumnExtractor.php
+++ b/packages/sonata-import-bundle/Tests/Import/Fixtures/CallTrackingColumnExtractor.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Draw\Bundle\SonataImportBundle\Tests\Import\Fixtures;
+
+use Draw\Bundle\SonataImportBundle\Column\BaseColumnExtractor;
+use Draw\Bundle\SonataImportBundle\Entity\Column;
+
+class CallTrackingColumnExtractor extends BaseColumnExtractor
+{
+    public int $callCount = 0;
+
+    public mixed $lastValue = null;
+
+    #[\Override]
+    public function assign(object $object, Column $column, mixed $value): bool
+    {
+        ++$this->callCount;
+        $this->lastValue = $value;
+
+        return true;
+    }
+}

--- a/packages/sonata-import-bundle/Tests/Import/ImporterTest.php
+++ b/packages/sonata-import-bundle/Tests/Import/ImporterTest.php
@@ -1,0 +1,161 @@
+<?php
+
+namespace Draw\Bundle\SonataImportBundle\Tests\Import;
+
+use Draw\Bundle\SonataImportBundle\Column\BaseColumnExtractor;
+use Draw\Bundle\SonataImportBundle\Column\ColumnExtractorInterface;
+use Draw\Bundle\SonataImportBundle\Column\ColumnFactory;
+use Draw\Bundle\SonataImportBundle\Entity\Column;
+use Draw\Bundle\SonataImportBundle\Import\Importer;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Notifier\NotifierInterface;
+
+/**
+ * @internal
+ */
+#[CoversClass(Importer::class)]
+class ImporterTest extends TestCase
+{
+    public function testIsSkipValueDefault(): void
+    {
+        $importer = $this->createImporter();
+
+        static::assertSame('_SKIP_', $importer->getSkipValue());
+        static::assertTrue($importer->isSkipValue('_SKIP_'));
+        static::assertFalse($importer->isSkipValue(''));
+        static::assertFalse($importer->isSkipValue(null));
+        static::assertFalse($importer->isSkipValue(0));
+        static::assertFalse($importer->isSkipValue('skip'));
+        static::assertFalse($importer->isSkipValue(' _SKIP_ '));
+        static::assertFalse($importer->isSkipValue(new \DateTime()));
+    }
+
+    public function testIsSkipValueCustomMarker(): void
+    {
+        $importer = $this->createImporter(skipValue: '*SKIP*');
+
+        static::assertSame('*SKIP*', $importer->getSkipValue());
+        static::assertTrue($importer->isSkipValue('*SKIP*'));
+        static::assertFalse($importer->isSkipValue('_SKIP_'));
+    }
+
+    public function testAssignValueSkipsExtractorsForMarker(): void
+    {
+        $extractor = $this->createCallTrackingExtractor();
+        $importer = $this->createImporter([$extractor]);
+
+        $object = new \stdClass();
+        $column = (new Column())->setMappedTo('label');
+
+        $this->invokeAssign($importer, $object, $column, '_SKIP_');
+
+        static::assertSame(0, $extractor->callCount, 'Extractors must not be invoked for skip values.');
+        static::assertObjectNotHasProperty('label', $object);
+    }
+
+    public function testAssignValueSkipsBeforeDateCoercion(): void
+    {
+        $extractor = $this->createCallTrackingExtractor();
+        $importer = $this->createImporter([$extractor]);
+
+        $object = new \stdClass();
+        $column = (new Column())
+            ->setMappedTo('createdAt')
+            ->setIsDate(true)
+        ;
+
+        $this->invokeAssign($importer, $object, $column, '_SKIP_');
+
+        static::assertSame(0, $extractor->callCount);
+    }
+
+    public function testAssignValueRunsExtractorsForRegularValue(): void
+    {
+        $extractor = $this->createCallTrackingExtractor();
+        $importer = $this->createImporter([$extractor]);
+
+        $object = new \stdClass();
+        $column = (new Column())->setMappedTo('label');
+
+        $this->invokeAssign($importer, $object, $column, 'Real value');
+
+        static::assertSame(1, $extractor->callCount);
+        static::assertSame('Real value', $extractor->lastValue);
+    }
+
+    public function testAssignValueEmptyStringIsNotASkip(): void
+    {
+        $extractor = $this->createCallTrackingExtractor();
+        $importer = $this->createImporter([$extractor]);
+
+        $object = new \stdClass();
+        $column = (new Column())->setMappedTo('label');
+
+        $this->invokeAssign($importer, $object, $column, '');
+
+        static::assertSame(1, $extractor->callCount, 'Empty string must still be passed to extractors so the field can be cleared.');
+        static::assertSame('', $extractor->lastValue);
+    }
+
+    public static function provideNonSkipValues(): array
+    {
+        return [
+            'empty string' => [''],
+            'whitespace' => [' '],
+            'lowercase skip' => ['_skip_'],
+            'padded marker' => [' _SKIP_ '],
+            'integer zero' => [0],
+            'integer minus one' => [-1],
+            'null' => [null],
+            'similar marker' => ['SKIP'],
+        ];
+    }
+
+    #[DataProvider('provideNonSkipValues')]
+    public function testIsSkipValueRejectsNonExactMatches(mixed $value): void
+    {
+        $importer = $this->createImporter();
+
+        static::assertFalse($importer->isSkipValue($value));
+    }
+
+    /**
+     * @param iterable<ColumnExtractorInterface> $extractors
+     */
+    private function createImporter(iterable $extractors = [], string $skipValue = Importer::DEFAULT_SKIP_VALUE): Importer
+    {
+        return new Importer(
+            $extractors,
+            $this->createStub(\Doctrine\Persistence\ManagerRegistry::class),
+            $this->createStub(ColumnFactory::class),
+            $this->createStub(NotifierInterface::class),
+            $skipValue,
+        );
+    }
+
+    private function createCallTrackingExtractor(): BaseColumnExtractor
+    {
+        return new class extends BaseColumnExtractor {
+            public int $callCount = 0;
+
+            public mixed $lastValue = null;
+
+            #[\Override]
+            public function assign(object $object, Column $column, mixed $value): bool
+            {
+                ++$this->callCount;
+                $this->lastValue = $value;
+
+                return true;
+            }
+        };
+    }
+
+    private function invokeAssign(Importer $importer, object $object, Column $column, mixed $value): void
+    {
+        $reflection = new \ReflectionMethod(Importer::class, 'assignValue');
+        $reflection->invoke($importer, $object, $column, $value);
+    }
+}

--- a/packages/sonata-import-bundle/Tests/Import/ImporterTest.php
+++ b/packages/sonata-import-bundle/Tests/Import/ImporterTest.php
@@ -2,11 +2,11 @@
 
 namespace Draw\Bundle\SonataImportBundle\Tests\Import;
 
-use Draw\Bundle\SonataImportBundle\Column\BaseColumnExtractor;
 use Draw\Bundle\SonataImportBundle\Column\ColumnExtractorInterface;
 use Draw\Bundle\SonataImportBundle\Column\ColumnFactory;
 use Draw\Bundle\SonataImportBundle\Entity\Column;
 use Draw\Bundle\SonataImportBundle\Import\Importer;
+use Draw\Bundle\SonataImportBundle\Tests\Import\Fixtures\CallTrackingColumnExtractor;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
@@ -43,7 +43,7 @@ class ImporterTest extends TestCase
 
     public function testAssignValueSkipsExtractorsForMarker(): void
     {
-        $extractor = $this->createCallTrackingExtractor();
+        $extractor = new CallTrackingColumnExtractor();
         $importer = $this->createImporter([$extractor]);
 
         $object = new \stdClass();
@@ -57,7 +57,7 @@ class ImporterTest extends TestCase
 
     public function testAssignValueSkipsBeforeDateCoercion(): void
     {
-        $extractor = $this->createCallTrackingExtractor();
+        $extractor = new CallTrackingColumnExtractor();
         $importer = $this->createImporter([$extractor]);
 
         $object = new \stdClass();
@@ -73,7 +73,7 @@ class ImporterTest extends TestCase
 
     public function testAssignValueRunsExtractorsForRegularValue(): void
     {
-        $extractor = $this->createCallTrackingExtractor();
+        $extractor = new CallTrackingColumnExtractor();
         $importer = $this->createImporter([$extractor]);
 
         $object = new \stdClass();
@@ -87,7 +87,7 @@ class ImporterTest extends TestCase
 
     public function testAssignValueEmptyStringIsNotASkip(): void
     {
-        $extractor = $this->createCallTrackingExtractor();
+        $extractor = new CallTrackingColumnExtractor();
         $importer = $this->createImporter([$extractor]);
 
         $object = new \stdClass();
@@ -133,24 +133,6 @@ class ImporterTest extends TestCase
             static::createStub(NotifierInterface::class),
             $skipValue,
         );
-    }
-
-    private function createCallTrackingExtractor(): BaseColumnExtractor
-    {
-        return new class extends BaseColumnExtractor {
-            public int $callCount = 0;
-
-            public mixed $lastValue = null;
-
-            #[\Override]
-            public function assign(object $object, Column $column, mixed $value): bool
-            {
-                ++$this->callCount;
-                $this->lastValue = $value;
-
-                return true;
-            }
-        };
     }
 
     private function invokeAssign(Importer $importer, object $object, Column $column, mixed $value): void

--- a/packages/sonata-import-bundle/Tests/Import/ImporterTest.php
+++ b/packages/sonata-import-bundle/Tests/Import/ImporterTest.php
@@ -99,7 +99,15 @@ class ImporterTest extends TestCase
         static::assertSame('', $extractor->lastValue);
     }
 
-    public static function provideNonSkipValues(): array
+    #[DataProvider('provideIsSkipValueRejectsNonExactMatchesCases')]
+    public function testIsSkipValueRejectsNonExactMatches(mixed $value): void
+    {
+        $importer = $this->createImporter();
+
+        static::assertFalse($importer->isSkipValue($value));
+    }
+
+    public static function provideIsSkipValueRejectsNonExactMatchesCases(): iterable
     {
         return [
             'empty string' => [''],
@@ -113,14 +121,6 @@ class ImporterTest extends TestCase
         ];
     }
 
-    #[DataProvider('provideNonSkipValues')]
-    public function testIsSkipValueRejectsNonExactMatches(mixed $value): void
-    {
-        $importer = $this->createImporter();
-
-        static::assertFalse($importer->isSkipValue($value));
-    }
-
     /**
      * @param iterable<ColumnExtractorInterface> $extractors
      */
@@ -128,9 +128,9 @@ class ImporterTest extends TestCase
     {
         return new Importer(
             $extractors,
-            $this->createStub(\Doctrine\Persistence\ManagerRegistry::class),
-            $this->createStub(ColumnFactory::class),
-            $this->createStub(NotifierInterface::class),
+            static::createStub(\Doctrine\Persistence\ManagerRegistry::class),
+            static::createStub(ColumnFactory::class),
+            static::createStub(NotifierInterface::class),
             $skipValue,
         );
     }


### PR DESCRIPTION
## What

The Sonata import (`/admin/draw/sonataimport/import/create`) writes every mapped CSV cell to the entity. When a content editor wants to update only one locale of a translatable field (or one of several scalar columns), they currently have to repeat every other locale/column — otherwise the importer overwrites the stored value with whatever is in the cell (often a placeholder like `n/a` or an empty string).

This PR adds a per-cell *skip* sentinel: when a cell equals the configured marker (default `_SKIP_`), assignment for that `(row, column)` pair is short-circuited and the existing value on the entity is preserved.

```csv
id,translation#en.title,translation#fr.title,translation#pl.title
42,Ocean kingdom,Royaume océanique,_SKIP_
```

For row `id=42`, the English and French titles are updated and the Polish title is left exactly as it is in the database.


